### PR TITLE
more readable css

### DIFF
--- a/css/guide.css
+++ b/css/guide.css
@@ -3,7 +3,16 @@ html {
     font-size: 17px;
     line-height: 1.68;
     color: #1a1a1a;
-    min-width: 1104px;
+}
+
+main, p {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+img {
+  max-width: 100%;
 }
 
 body {
@@ -290,7 +299,8 @@ table.impls {
     margin: 2rem 0 2rem;
     font-size: 13px;
     line-height: 1.5;
-    width: 1072px;
+//    width: 1072px;
+    width: 100%;
     table-layout: fixed;
 }
 
@@ -313,7 +323,7 @@ table.impls tr {
 
 table.impls th {
     text-align: left;
-    width: calc((1072px - 184px - 6px) / 4);
+//    width: calc((1072px - 184px - 6px) / 4);
 }
 
 table.impls .byline {
@@ -475,3 +485,4 @@ table.impls a:hover {
     font-weight: normal;
     font-style: italic;
 }
+


### PR DESCRIPTION
I had difficulty reading the text because the lines were very long, and started very close to the margin (reading on firefox). For maximum readability, text should be layed out about the same amount on a line as you'd get in a book. book publishers have spent hundreds of years figuring out how to best lay out text so copy them. I can see there is some sort of grid layout system here (which I don't really understand) but these changes displayed nicely for me. (also, layout is responsive, images will shrink if necessary to view on screen)