### PR TITLE
type is mandatory, not polite

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,7 +806,7 @@ assert_nacl_sign_verify_detached(
             </tr>
             <tr>
                 <td>content</td>
-                <td>Free-form JSON. It is up to applications to interpret what it means. It’s polite to specify a <em>type</em> field so that applications can easily filter out message types they don’t understand.</td>
+                <td>Free-form JSON. It is up to applications to interpret what it means. A mandatory <em>type</em> field, a string, between 3 and 52 utf8 chars long (inclusive). This is used so that applications can easily filter out message types they don’t understand.</td>
             </tr>
         </table>
 


### PR DESCRIPTION
plaintext messages without type are rejected:
https://github.com/ssbc/ssb-validate/blob/master/index.js#L43-L47

(note, encrypted messages may be missing type, or contain arbitary binary data. we cannot validate encrypted messages unless we can decrypt them)