### PR TITLE
update Go links to cryptoscope org

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,8 +182,8 @@
             <div class="lang">Py</div>
             <div class="vs"><a href="https://github.com/pferreir/PySecretHandshake/blob/master/secret_handshake/crypto.py">crypto.py</a></div>
             <div class="lang">Go</div>
-            <div class="vs"><a href="https://github.com/cryptix/secretstream/blob/master/secrethandshake/state.go">state.go</a></div>
-            <div class="vs"><a href="https://github.com/cryptix/secretstream/blob/master/secrethandshake/conn.go">conn.go</a></div>
+            <div class="vs"><a href="https://github.com/cryptoscope/secretstream/blob/ad7542b0cbda422a1ea3de7efa62a514672a2c88/secrethandshake/state.go">state.go</a></div>
+            <div class="vs"><a href="https://github.com/cryptoscope/secretstream/blob/ad7542b0cbda422a1ea3de7efa62a514672a2c88/secrethandshake/conn.go">conn.go</a></div>
             <div class="lang">C</div>
             <div class="vs"><a href="https://github.com/AljoschaMeyer/shs1-c/blob/master/src/shs1.c">shs1.c</a></div>
             <div class="vs"><a href="https://git.scuttlebot.io/%25133ulDgs%2FoC1DXjoK04vDFy6DgVBB%2FZok15YJmuhD5Q%3D.sha256/blob/fd953a1e72b4b16e6e5a74bcf2f893dbf1407ce4/sbotc.c">sbotc.c</a></div>
@@ -475,8 +475,8 @@ assert_nacl_sign_verify_detached(
             <div class="lang">Py</div>
             <div class="vs"><a href="https://github.com/pferreir/PySecretHandshake/blob/master/secret_handshake/boxstream.py">boxstream.py</a></div>
             <div class="lang">Go</div>
-            <div class="vs"><a href="https://github.com/cryptix/secretstream/blob/master/boxstream/box.go">box.go</a></div>
-            <div class="vs"><a href="https://github.com/cryptix/secretstream/blob/master/boxstream/unbox.go">unbox.go</a></div>
+            <div class="vs"><a href="https://github.com/cryptoscope/secretstream/blob/ad7542b0cbda422a1ea3de7efa62a514672a2c88/boxstream/box.go">box.go</a></div>
+            <div class="vs"><a href="https://github.com/cryptoscope/secretstream/blob/ad7542b0cbda422a1ea3de7efa62a514672a2c88/boxstream/unbox.go">unbox.go</a></div>
             <div class="lang">C</div>
             <div class="vs"><a href="https://github.com/AljoschaMeyer/box-stream-c/blob/master/src/box-stream.c">box-stream.c</a></div>
             <div class="vs"><a href="https://git.scuttlebot.io/%25133ulDgs%2FoC1DXjoK04vDFy6DgVBB%2FZok15YJmuhD5Q%3D.sha256/blob/fd953a1e72b4b16e6e5a74bcf2f893dbf1407ce4/sbotc.c">sbotc.c</a></div>
@@ -508,7 +508,8 @@ assert_nacl_sign_verify_detached(
             <div class="vs"><a href="https://github.com/pferreir/pyssb/blob/master/ssb/packet_stream.py">packet_stream.py</a></div>
             <div class="vs"><a href="https://github.com/pferreir/pyssb/blob/master/ssb/muxrpc.py">muxrpc.py</a></div>
             <div class="lang">Go</div>
-            <div class="vs"><a href="https://github.com/cryptix/go-muxrpc/blob/master/client.go">client.go</a></div>
+            <div class="vs"><a href="https://github.com/cryptoscope/go-muxrpc/blob/601b7be81ee6b2bd6f32b1247e4688537f696794/codec">codec</a></div>
+            <div class="vs"><a href="https://github.com/cryptoscope/go-muxrpc/blob/601b7be81ee6b2bd6f32b1247e4688537f696794/rpc.go">rpc.go</a></div>
             <div class="lang">C</div>
             <div class="vs"><a href="https://git.scuttlebot.io/%25133ulDgs%2FoC1DXjoK04vDFy6DgVBB%2FZok15YJmuhD5Q%3D.sha256/blob/fd953a1e72b4b16e6e5a74bcf2f893dbf1407ce4/sbotc.c">sbotc.c</a></div>
         </aside>


### PR DESCRIPTION
updates #11

I wasn't sure what the stance on permalinks (with tree hashes) is but I thought they would be more future proof. Even if they need to be updated, they won't point no where if stuff moves on.