### PR TITLE
content maybe string if the message is encrypted

### DIFF
--- a/index.html
+++ b/index.html
@@ -815,7 +815,7 @@ assert_nacl_sign_verify_detached(
             </tr>
             <tr>
                 <td>content</td>
-                <td>Dictionary containing free-form data for applications to interpret, plus a mandatory <em>type</em> field. The <em>type</em> field allows applications to filter out message types they don’t understand and must be a string between 3 and 52 characters long (inclusive).</td>
+                <td>If the message is not encrypted, This is a dictionary containing free-form data for applications to interpret, plus a mandatory <em>type</em> field. The <em>type</em> field allows applications to filter out message types they don’t understand and must be a string between 3 and 52 characters long (inclusive). If this is a base64 encoded string, followed by a suffiix of <code>.box</code></td>
             </tr>
         </table>
         <aside style="align-self: start; position: relative; top: 19px;">


### PR DESCRIPTION
I was working on the documentation drive, and putting links to here from the ssb-keys and I realized that the protocol guide wasn't mentioning that content can be a string if the message is encrypted!