### PR TITLE
Fixes typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@ shared_secret_aB = nacl_scalarmult(
 )
 
 shared_secret_aB = nacl_scalarmult(
-  sk_to_curve25519(server_longterm_sk),
+  pk_to_curve25519(server_longterm_sk),
   client_ephemeral_pk
 )</code></pre>
         </figure>


### PR DESCRIPTION
This section of the protocol documentation tells how both the server and client create the same shared secret key so they can know they are talking to each other. However, the pseudocode function signatures were different. Looks like there was a typo in the function name, and it felt like there were a different operation in the server side to execute the same operation.