### PR TITLE
removed "not jerks" qualifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         <hr/>
     
         <p id="introduction" class="first"><a href="https://www.scuttlebutt.nz/">Scuttlebutt</a> is a protocol for building decentralized applications that work well offline and that no one person can control. Because there is no central server, Scuttlebutt clients connect to their peers to exchange information. This guide describes the protocols used to communicate within the Scuttlebutt network.</p>
-        <p>Scuttlebutt is a flexible protocol, capable of supporting many different types of applications. One of its first applications was as a social network, and it has also become one of the most compelling because the people who hang out there are not jerks. This guide has a slight focus on how to use Scuttlebutt for social networking, but many of the explanations will still be useful if want to use it for something completely different, or are just curious how it works.</p>
+        <p>Scuttlebutt is a flexible protocol, capable of supporting many different types of applications. One of its first applications was as a social network. This guide has a slight focus on how to use Scuttlebutt for social networking, but many of the explanations will still be useful if want to use it for something completely different, or are just curious how it works.</p>
 
         <h2 id="keys-and-identities">Keys and identities</h2>
         <p>The first thing a user needs to participate in Scuttlebutt is an identity. An identity is an Ed25519 key pair and typically represents a person, a device, a server or a bot. It’s normal for a person to have several Scuttlebutt identities.</p>
@@ -237,8 +237,8 @@ assert_nacl_auth_verify(
         </figure>
 
         <div>
-            <p>First the client sends their <img class="inline-key" src="img/key_little_a_public.png"/> generated ephemeral key. Also included is an hmac that indicates the client wishes to use their key with this specific instance of the Scuttlebutt network.</p>
-            <p>The <img class="inline-key" src="img/key_big_n.png"/> network identifier is a fixed key. On the main Scuttlebutt network it is the following 32-byte sequence:</p>
+            <p>First the client sends their <img class="inline-key" src="img/key_little_a_public.png"/> generated ephemeral key. Also included is an hmac that indicates the client wishes to use their key with this specific instance of the Scuttlebutt network.</p>
+            <p>The <img class="inline-key" src="img/key_big_n.png"/> network identifier is a fixed key. On the main Scuttlebutt network it is the following 32-byte sequence:</p>
             <div class="fixed-key binary">
                 <span>d4</span><span>a1</span><span>cb</span><span>88</span><span>a6</span><span>6f</span><span>02</span><span>f8</span><span>db</span><span>63</span><span>5c</span><span>e2</span><span>64</span><span>41</span><span>cc</span><span>5d</span>
                 <span>ac</span><span>1b</span><span>08</span><span>42</span><span>0c</span><span>ea</span><span>ac</span><span>23</span><span>08</span><span>39</span><span>b7</span><span>55</span><span>84</span><span>5a</span><span>9f</span><span>fb</span>
@@ -277,7 +277,7 @@ assert_nacl_auth_verify(
 )</code></pre>
         </figure>
 
-        <p>The server responds with their own <img class="inline-key" src="img/key_little_b_public.png"/> ephemeral public key and hmac. The client stores the key and verifies that they are also using the same network identifier.</p>
+        <p>The server responds with their own <img class="inline-key" src="img/key_little_b_public.png"/> ephemeral public key and hmac. The client stores the key and verifies that they are also using the same network identifier.</p>
 
         <h4 id="shared-secret-derivation-1">Shared secret derivation</h4>
         <img src="img/shared_secret_derivation_1.png" style="height: 220px;"/>
@@ -306,9 +306,9 @@ shared_secret_aB = nacl_scalarmult(
         </figure>
 
         <div>
-            <p>Now that ephemeral keys have been exchanged, both ends use them to derive a shared secret <img class="inline-key" src="img/key_little_a_little_b.png"/> using scalar multiplication.</p>
-            <p>The client and server each combine their own ephemeral secret key with the other’s ephemeral public key to produce the same shared secret on both ends. An eavesdropper doesn’t know either secret key so they can’t generate the shared secret. A man-in-the-middle could swap out the ephemeral keys in Messages 1 and 2 for their own keys, so the shared secret <img class="inline-key" src="img/key_little_a_little_b.png"/> alone is not enough for the client and server to know that they are talking to each other and not a man-in-the-middle.</p>
-            <p>Because the client already knows the <img class="inline-key" src="img/key_big_b_public.png"/> server’s long term public key, both ends derive a second secret <img class="inline-key" src="img/key_little_a_big_b.png"/> that will allow the client to send a message that only the real server can read and not a man-in-the-middle.</p>
+            <p>Now that ephemeral keys have been exchanged, both ends use them to derive a shared secret <img class="inline-key" src="img/key_little_a_little_b.png"/> using scalar multiplication.</p>
+            <p>The client and server each combine their own ephemeral secret key with the other’s ephemeral public key to produce the same shared secret on both ends. An eavesdropper doesn’t know either secret key so they can’t generate the shared secret. A man-in-the-middle could swap out the ephemeral keys in Messages 1 and 2 for their own keys, so the shared secret <img class="inline-key" src="img/key_little_a_little_b.png"/> alone is not enough for the client and server to know that they are talking to each other and not a man-in-the-middle.</p>
+            <p>Because the client already knows the <img class="inline-key" src="img/key_big_b_public.png"/> server’s long term public key, both ends derive a second secret <img class="inline-key" src="img/key_little_a_big_b.png"/> that will allow the client to send a message that only the real server can read and not a man-in-the-middle.</p>
         </div>
         <aside>
             <p><strong>Scalar multiplication</strong> is a function for deriving shared secrets from a pair of secret and public Curve25519 keys.</p>
@@ -374,7 +374,7 @@ assert_nacl_sign_verify_detached(
         </figure>
 
         <div>
-            <p>The client reveals their identity to the server by sending their <img class="inline-key" src="img/key_big_a_public.png"/> long term public key. The client also makes a signature using their <img class="inline-key" src="img/key_big_a_secret.png"/> long term secret key. By signing the keys used earlier in the handshake the client proves their identity and confirms that they do indeed wish to be part of this handshake.</p>
+            <p>The client reveals their identity to the server by sending their <img class="inline-key" src="img/key_big_a_public.png"/> long term public key. The client also makes a signature using their <img class="inline-key" src="img/key_big_a_secret.png"/> long term secret key. By signing the keys used earlier in the handshake the client proves their identity and confirms that they do indeed wish to be part of this handshake.</p>
             <p>The client’s message is enclosed in a secret box to ensure that only the server can read it. Upon receiving it, the server opens the box, stores the client’s long term public key and verifies the signature.</p>
             <p>An all-zero nonce is used for the secret box. The secret box construction requires that all secret boxes using a particular key must use different nonces. It’s important to get this detail right because reusing a nonce will allow an attacker to recover the key and encrypt or decrypt any secret boxes using that key. Using a zero nonce is allowed here because this is the only secret box that ever uses the key <span class="key-formula">sha256(concat( <img class="inline-key" src="img/key_big_n.png"/>, <img class="inline-key" src="img/key_little_a_little_b.png"/>, <img class="inline-key" src="img/key_little_a_big_b.png"/>))</span>.</p>
         </div>
@@ -399,7 +399,7 @@ assert_nacl_sign_verify_detached(
 )</code></pre>
         </figure>
 
-        <p>Now that the server knows the <img class="inline-key" src="img/key_big_a_public.png"/> client’s long term public key, another shared secret <img class="inline-key" src="img/key_big_a_little_b.png"/> is derived by both ends. The server uses this shared secret to send a message that only the real client can read and not a man-in-the-middle.</p>
+        <p>Now that the server knows the <img class="inline-key" src="img/key_big_a_public.png"/> client’s long term public key, another shared secret <img class="inline-key" src="img/key_big_a_little_b.png"/> is derived by both ends. The server uses this shared secret to send a message that only the real client can read and not a man-in-the-middle.</p>
 
         <h4 id="server-accept">4. Server accept</h4>
         <img src="img/server_accept.png" style="height: 400px;"/>
@@ -453,7 +453,7 @@ assert_nacl_sign_verify_detached(
   )
 )</code></pre>
         </figure>
-        <p>The server accepts the handshake by signing a message using their <img class="inline-key" src="img/key_big_b_secret.png"/> long term secret key. It includes a copy of the client’s previous signature. The server’s signature is enclosed in a secret box using all of the shared secrets.</p>
+        <p>The server accepts the handshake by signing a message using their <img class="inline-key" src="img/key_big_b_secret.png"/> long term secret key. It includes a copy of the client’s previous signature. The server’s signature is enclosed in a secret box using all of the shared secrets.</p>
         <p>Upon receiving it, the client opens the box and verifies the server’s signature.</p>
         <p>Similarly to the previous message, this secret box also uses an all-zero nonce because it is the only secret box that ever uses the key <span class="key-formula">sha256(concat( <img class="inline-key" src="img/key_big_n.png"/>, <img class="inline-key" src="img/key_little_a_little_b.png"/>, <img class="inline-key" src="img/key_little_a_big_b.png"/>, <img class="inline-key" src="img/key_big_a_little_b.png"/>))</span>.</p>
 


### PR DESCRIPTION
The marketing position of the removed statement:

> , and it has also become one of the most compelling because the people who hang out there are not jerks

While seemingly innocuous to those who believe it, is sententious in that it assumes that all those using scuttlebutt are not jerks (if that is the case, why have a code of conduct), and serves as gas lighting for those whose experiences on the platform is with people they found to be jerks (was I the jerk?).

Furthermore the "not jerks" sentiment is one of the author(s) having the fortune (or misfortune) of sharing a similar worldview with their peers, which is a position of privilege, which is not a circumstance that is shared by many who are in need of such a platform, who have been rejected by the pompous worldview imperialism surrounding them, where they may want to have a refuge from what their circumstances has considered as jerks.

This divergence of who and what are jerks, should be celebrated or at least accepted in the marketing, especially on a decentralised platform; not culturally dismissed with one worldview as the moral arbiter of the others (the "not jerks" worldview).

Worldview nationalism is fine for any community to maintain itself, such as the dev team, which is why this is not an objection to any one community's code of conduct, but it is a rectification of the marketing of a decentralised platform currently having a moral centralisation for its decentralised users.

If an aggrandising statement remains necessary, then I would suggest any of the following to be iterated on:

> and it has also become one of the most compelling because people can formulate their own communities to their own standards.

> and it has also become one of the most compelling because people can formulate their own digital homes around those they like.

I would also suggest that the pub server listing linked to from the getting started guide states which conduct is expected on each. So that people can select the pub where they won't be considered a jerk, and avoid the pubs where they would. This would improve the initial community experience to accomodate the divergence of people, reducing them bailing on the platform when they do not jive with the predominant culture, but can formulate and be welcomed within their own communities, just like how, as the removed statement affirms, those jiving with the predominant culture of this community has the opportunity of enjoying today. Bailing of this divergence only hurts the momentum of the platform, as it ejects the various contributions (some bad, some good) of those dissimilar which constrains the platform's entropic evolution.