### PR TITLE
Fix description of encrypted 'content' in the message format

### DIFF
--- a/index.html
+++ b/index.html
@@ -815,7 +815,7 @@ assert_nacl_sign_verify_detached(
             </tr>
             <tr>
                 <td>content</td>
-                <td>If the message is not encrypted, This is a dictionary containing free-form data for applications to interpret, plus a mandatory <em>type</em> field. The <em>type</em> field allows applications to filter out message types they don’t understand and must be a UTF-16 string between 3 and 52 code units long (inclusive). If this is a base64 encoded string, followed by a suffix of <code>.box</code></td>
+                <td>If the message is not encrypted, This is a dictionary containing free-form data for applications to interpret, plus a mandatory <em>type</em> field. The <em>type</em> field allows applications to filter out message types they don’t understand and must be a UTF-16 string between 3 and 52 code units long (inclusive). If the message is encrypted, then this is a base64 encoded string, followed by a suffix of <code>.box</code>; we will describe private messages later in this document.</td>
             </tr>
         </table>
         <aside style="align-self: start; position: relative; top: 19px;">


### PR DESCRIPTION
It looks like the sentence was cut-off when writing it, so I tried
to fill in using the description later in the document, I hope that's
accurate.