### PR TITLE
Disambiguate pub invites

### DIFF
--- a/index.html
+++ b/index.html
@@ -1560,6 +1560,7 @@ assert_nacl_sign_verify_detached(
         <p>After joining a pub, a user may decide to follow some of its members directly, in which case the pub is no longer needed for feed visibility but is still useful for accepting TCP connections and replicating messages.</p>
 
         <h3 id="invites">Invites</h3>
+        <p><i>This section describes the original pub invitations, also referred to as the followbot system or legacy invites, not to be confused with <a href="#rooms-joining">room invites</a> or <a href="https://github.com/ssbc/ssb-peer-invites">peer invites</a></i>.
         <p>Any user can follow a pub by posting a follow message, but to get the pub to follow you back you need an invite.</p>
         <div>
             <p>How the pub hands out invites is for its operator to decide. Some pubs have a web page that anybody can visit to generate an invite code. Some pubs have a pre-generated list of invite codes that the operator distributes. Invite codes can be single-use-only, have a maximum number of uses before they expire, or keep working indefinitely. A single user can use several invites if they wish to join several different pubs.</p>


### PR DESCRIPTION
This adds a small blurb to help clarify which sort of invites the Pub Invites section is describing. We have at least three types of invites on SSB: pub invites, peer invites, and room invites, and this helps readers stay aware that when they see the term "invite" it could mean one of several things.