### PR TITLE
Add link to fusion identity spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,7 +1209,7 @@ assert_nacl_sign_verify_detached(
         <h3 id="metafeed-fusion-identity">Fusion Identity</h3>
         <p>Fusion Identities solve the challenge of using multiple devices with Secure Scuttlebutt. Each device still uses it's own identity, there is no avoiding that, but they can now share fusion identities with each other. These new fusion identities can be used to compute mentions and notifications taking into account all the keys that are part of the fusion. They also make it possible to send private messages to the fusion identity which are readable by all the members of the fusion identity. Replicating multiple feeds from the same user can be done by following the fusion identity.</p>
         <aside>
-            <p>Check out the <a href="https://github.com/ssb-ngi-pointer/fusion-identity-spec" targer="_blank">Fusion Identity specification</a> for more information.</p>
+            <p>Check out the <a href="https://github.com/ssb-ngi-pointer/fusion-identity-spec" target="_blank">Fusion Identity specification</a> for more information.</p>
         </aside>
 
         <!-- end of metafeeds documentation -->

--- a/index.html
+++ b/index.html
@@ -1209,7 +1209,7 @@ assert_nacl_sign_verify_detached(
         <h3 id="metafeed-fusion-identity">Fusion Identity</h3>
         <p>Fusion Identities solve the challenge of using multiple devices with Secure Scuttlebutt. Each device still uses it's own identity, there is no avoiding that, but they can now share fusion identities with each other. These new fusion identities can be used to compute mentions and notifications taking into account all the keys that are part of the fusion. They also make it possible to send private messages to the fusion identity which are readable by all the members of the fusion identity. Replicating multiple feeds from the same user can be done by following the fusion identity.</p>
         <aside>
-            <p>Check out the <a href="" targer="_blank">Fusion Identity specification</a> for more information.</p>
+            <p>Check out the <a href="https://github.com/ssb-ngi-pointer/fusion-identity-spec" targer="_blank">Fusion Identity specification</a> for more information.</p>
         </aside>
 
         <!-- end of metafeeds documentation -->


### PR DESCRIPTION
Noticed that this was missing